### PR TITLE
fix: properly type `useOneSignal`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -876,7 +876,7 @@ const OneSignalVue: IOneSignal = {
 
 const INJECT_KEY = "onesignal";
 
-export const useOneSignal = () => {
+export function useOneSignal(): IOneSignal {
   return inject(INJECT_KEY);
 }
 


### PR DESCRIPTION
This PR fixes the `useOneSignal` composable by adding a return type. Currently, there is no way for the compiler to know about it (that's how `provide`/`inject` is designed), so we need to specify it. 

After this PR, the following changes will occur in `index.d.ts`:

```diff
- export declare const useOneSignal: () => unknown;
+ export declare function useOneSignal: () => IOneSignal;
```

(I also changed `const` to `function` because it's more appropriate, though it doesn't change anything in practice for the end-user)