### PR TITLE
refactor: do not use `provide`/`inject`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { App, inject } from 'vue';
+import { App } from 'vue';
 
 const ONESIGNAL_SDK_ID = 'onesignal-sdk';
 const ONE_SIGNAL_SCRIPT_SRC = 'https://cdn.onesignal.com/sdks/OneSignalSDK.js';
@@ -874,17 +874,14 @@ const OneSignalVue: IOneSignal = {
 	sendOutcome,
 };
 
-const INJECT_KEY = "onesignal";
-
 export const useOneSignal = () => {
-  return inject(INJECT_KEY);
+  return OneSignalVue;
 }
 
 const OneSignalVuePlugin = {
   install(app: App, options: IInitObject) {
     app.config.globalProperties.$OneSignal = OneSignalVue as IOneSignal;
     app.config.globalProperties.$OneSignal.init(options);
-    app.provide(INJECT_KEY, OneSignalVue);
   }
 }
 


### PR DESCRIPTION
This PR changes how the `useOneSignal` composable work. Instead of using `provide`/`inject`, which would not work under some edge-cases (which I'll explain), it simply returns the `OneSignalVue` object.

The "edge-case" (not really rare actually) is that our logic is not inside components. We use `<script setup>` and only keep component-specific logic in there.

So in our case, we have external TypeScript files that are imported when needed, and one of them contain a call to the OneSignal composable in order to trigger the browser notification prompt. 

This doesn't work because [`provide`/`inject`](https://vuejs.org/guide/components/provide-inject.html#provide-inject) has been designed to work around "prop drilling", and is specific to usage inside of a component file. 

Returning the `OneSignalVue` does not bring any downside. It works the same and fixes this kind of architecture.