### PR TITLE
[fix](issue#42) Augmented Type Declaration Fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,7 @@ function addSDKScript() {
 }
 /* T Y P E   D E C L A R A T I O N S */
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $OneSignal: IOneSignalOneSignal;
   }


### PR DESCRIPTION
**Defination**
Onesignal global type breaks other global types #42 

**Example Error**
```
TSC gives error due to augmentation is on @vue/runtime-core
"[TYPE]" does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<{}, {}>
```

**Reproducing**
You can take a look at #42 for more details.

**What is changed?**
"@vue/runtime-core" augmentation changed to "vue" due to [vue documentation](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)

