### PR TITLE
ci: use dynamic import in "set response time" script

### DIFF
--- a/.github/os_probot_metadata.js
+++ b/.github/os_probot_metadata.js
@@ -1,9 +1,9 @@
+import { Octokit } from "@octokit/action"
+
 /**
  * Based on probot-metadata - https://github.com/probot/metadata
  */
 const regex = /\n\n<!-- probot = (.*) -->/
-
-const { Octokit } = require("@octokit/action")
 
 const octokit = new Octokit()
 


### PR DESCRIPTION
Replaces the `require()` import syntax with dynamic imports, fixing [this issue](https://github.com/OneSignal/onesignal-vue3/actions/runs/12714014512/job/35443194359) in the last action run.

Will possibly have to do the same in the [workflow file](https://github.com/OneSignal/onesignal-vue3/blob/41b92ae1149ca0abce0765dd179adf6c6a779f84/.github/workflows/set_response_time.yml#L26-L27).