### PR TITLE
sync with web-shim-codegen v3.0.5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Welcome to onesignal-vue3 👋</h1>
 <p>
-  <a href="https://www.npmjs.com/package/onesignal-vue3" target="_blank">
-    <img alt="Version" src="https://img.shields.io/npm/v/onesignal-vue3.svg">
+  <a href="https://www.npmjs.com/package/@onesignal/onesignal-vue3" target="_blank">
+    <img alt="Version" src="https://img.shields.io/npm/v/@onesignal/onesignal-vue3.svg">
   </a>
   <a href="https://github.com/OneSignal/onesignal-vue3#readme" target="_blank">
     <img alt="Documentation" src="https://img.shields.io/badge/documentation-yes-brightgreen.svg" />
@@ -19,7 +19,7 @@
 - 🏠 [Homepage](https://onesignal.com)
 - 🖤 [npm](https://www.npmjs.com/package/@onesignal/onesignal-vue3)
 
-OneSignal is the world's leader for Mobile Push Notifications, Web Push, and In-App Messaging. It is trusted by 2 million+ businesses to send 9 billion Push Notifications per day.
+OneSignal is the world's leader for Mobile Push Notifications, Web Push, and In-App Messaging. It is trusted by 2 million+ developers to send 12 billion Push Notifications per day.
 
 You can find more information on OneSignal [here](https://onesignal.com/).
 
@@ -130,7 +130,7 @@ this.$OneSignal
 
 ### Init Options
 
-You can pass other [options](https://documentation.onesignal.com/v11.0/docs/web-sdk#initializing-the-sdk) to the `init` function. Use these options to configure personalized prompt options, auto-resubscribe, and more.
+You can pass other [options](https://documentation.onesignal.com/docs/web-sdk-reference#init) to the `init` function. Use these options to configure personalized prompt options, auto-resubscribe, and more.
 
 <details>
   <summary>Expand to see more options</summary>
@@ -205,7 +205,7 @@ interface IOneSignalOneSignal {
 
 ### OneSignal API
 
-See the official [OneSignal WebSDK reference](https://documentation.onesignal.com/v11.0/docs/web-sdk) for information on all available SDK functions.
+See the official [OneSignal WebSDK reference](https://documentation.onesignal.com/docs/web-sdk) for information on all available SDK functions.
 
 ---
 
@@ -245,7 +245,7 @@ this.$OneSignal.Notifications.addEventListener('change', (event) => {
 });
 ```
 
-See the [OneSignal WebSDK Reference](https://documentation.onesignal.com/v11.0/docs/web-sdk) for all available event listeners.
+See the [OneSignal WebSDK Reference](https://documentation.onesignal.com/docs/web-sdk-reference#addeventlistener-push-notification) for all available event listeners.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -72,6 +72,11 @@ const init = (options: IInitObject): Promise<void> => {
     return Promise.reject(`Document is not defined.`);
   }
 
+  // Handle both disabled and disable keys for welcome notification
+  if (options.welcomeNotification?.disabled !== undefined) {
+    options.welcomeNotification.disable = options.welcomeNotification.disabled;
+  }
+
   return new Promise<void>((resolve, reject) => {
     window.OneSignalDeferred?.push((OneSignal) => {
       OneSignal.init(options)
@@ -340,8 +345,14 @@ export interface IInitObject {
   welcomeNotification?: {
     /**
      * Disables sending a welcome notification to new site visitors. If you want to disable welcome notifications, this is the only option you need.
+     * @deprecated Use 'disable' instead. This will be removed in a future version.
      */
     disabled?: boolean;
+
+    /**
+     * Disables sending a welcome notification to new site visitors. If you want to disable welcome notifications, this is the only option you need.
+     */
+    disable?: boolean;
 
     /**
      * The welcome notification's message. You can localize this to your own language.
@@ -359,7 +370,7 @@ export interface IInitObject {
      * By default, clicking the welcome notification does not open any link.
      * This is recommended because the user has just visited your site and subscribed.
      */
-    url: string;
+    url?: string;
   };
 
   /**
@@ -490,7 +501,7 @@ export interface IOneSignalSlidedown {
 	removeEventListener(event: SlidedownEventName, listener: (wasShown: boolean) => void): void;
 }
 export interface IOneSignalDebug {
-	setLogLevel(logLevel: string): void;
+	setLogLevel(logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'): void;
 }
 export interface IOneSignalSession {
 	sendOutcome(outcomeName: string, outcomeWeight?: number): Promise<void>;
@@ -877,9 +888,10 @@ function userRemoveTags(keys: string[]): void {
   });
   
 }
-function userGetTags(): { [key: string]: string } {
+// @ts-expect-error - return non-Promise type despite needing to await OneSignalDeferred
+async function userGetTags(): { [key: string]: string } {
   let retVal: { [key: string]: string };
-  window.OneSignalDeferred?.push((OneSignal) => {
+  await window.OneSignalDeferred?.push((OneSignal) => {
     retVal = OneSignal.User.getTags();
   });
   return retVal;
@@ -905,9 +917,10 @@ function userSetLanguage(language: string): void {
   });
   
 }
-function userGetLanguage(): string {
+// @ts-expect-error - return non-Promise type despite needing to await OneSignalDeferred
+async function userGetLanguage(): string {
   let retVal: string;
-  window.OneSignalDeferred?.push((OneSignal) => {
+  await window.OneSignalDeferred?.push((OneSignal) => {
     retVal = OneSignal.User.getLanguage();
   });
   return retVal;
@@ -960,7 +973,7 @@ function pushSubscriptionRemoveEventListener(event: 'change', listener: (change:
   });
   
 }
-function debugSetLogLevel(logLevel: string): void {
+function debugSetLogLevel(logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'): void {
   
   window.OneSignalDeferred?.push((OneSignal) => {
     OneSignal.Debug.setLogLevel(logLevel);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,13 @@
     "eslint-plugin-vue": "^9.17.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",


### PR DESCRIPTION
## Changes

- improve types for `setLogLevel` method
- pass `welcomeNotification.disabled` as `disable` to web SDK
- set `welcomeNotification.url` to be optional
- await `OneSignalDeferred` to complete processing for endpoints such as `getTags()` and `getLanguage()`
- improvements to distributed bundle size