### PR TITLE
feat: add `IDisplayableOSNotification` type 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -225,6 +225,10 @@ export interface IOSNotificationActionButton {
   readonly launchURL?: string;
 }
 
+export interface IDisplayableOSNotification extends IOSNotification {
+  display(): void;
+}
+
 export interface NotificationClickResult {
   readonly actionId?: string;
   readonly url?: string;
@@ -239,7 +243,7 @@ export type NotificationEventTypeMap = {
 };
 
 export interface NotificationForegroundWillDisplayEvent {
-  readonly notification: IOSNotification;
+  readonly notification: IDisplayableOSNotification;
   preventDefault(): void;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onesignal/onesignal-vue3",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onesignal/onesignal-vue3",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.2.0"


### PR DESCRIPTION
## Features

- adds the `IDisplayableOSNotification` interface including:
  - `display()` - re-displays a notification previously suppressed by `preventDefault()`