### PR TITLE
fix: reject init() when push is unsupported or script fails to load

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ const DEFAULT_SCRIPT_SRC =
 
 let isOneSignalInitialized = false;
 let isOneSignalScriptFailed = false;
+let pendingInitReject: ((reason?: unknown) => void) | undefined;
 
 if (typeof window !== 'undefined') {
   window.OneSignalDeferred = window.OneSignalDeferred || [];
@@ -15,6 +16,8 @@ if (typeof window !== 'undefined') {
 
 function handleOnError() {
   isOneSignalScriptFailed = true;
+  pendingInitReject?.(new Error('OneSignal script failed to load.'));
+  pendingInitReject = undefined;
 }
 
 function addSDKScript(scriptSrc?: string) {
@@ -71,6 +74,14 @@ const init = (options: IInitObject): Promise<void> => {
     return Promise.reject(`Document is not defined.`);
   }
 
+  // Required: the CDN script silently exits on unsupported browsers without
+  // draining OneSignalDeferred, so init() would hang forever otherwise.
+  if (!isPushNotificationsSupported()) {
+    return Promise.reject(
+      new Error('This browser does not support Web Push notifications.'),
+    );
+  }
+
   // Handle both disabled and disable keys for welcome notification
   if (options.welcomeNotification?.disabled !== undefined) {
     options.welcomeNotification.disable = options.welcomeNotification.disabled;
@@ -79,13 +90,18 @@ const init = (options: IInitObject): Promise<void> => {
   addSDKScript(options.scriptSrc);
 
   return new Promise<void>((resolve, reject) => {
+    pendingInitReject = reject;
     window.OneSignalDeferred?.push((OneSignal) => {
       OneSignal.init(options)
         .then(() => {
           isOneSignalInitialized = true;
+          pendingInitReject = undefined;
           resolve();
         })
-        .catch(reject);
+        .catch((err) => {
+          pendingInitReject = undefined;
+          reject(err);
+        });
     });
   });
 };


### PR DESCRIPTION
Syncs the generated wrapper with web-shim-codegen v3.0.8.

This release fixes a bug where `init()` would never settle: it now **rejects** instead of hanging when the browser does not support Web Push or the OneSignal SDK script fails to load. Previously the promise hung forever, which could freeze app startup (e.g. SSR/Nuxt hydration).

Upstream change: OneSignal/web-shim-codegen#138

Fixes #83